### PR TITLE
add liner.ai to the developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ curated list of top AI Tools.
 | Codeium | free AI powered code completion | [🔗](https://www.codeium.com/)|
 | Ghostwriter (by Replit) | AI pair programmer | [🔗](https://replit.com/site/ghostwriter)|
 | GitHub Copilot | an AI pair programmer | [🔗](https://github.com/features/copilot)|
+| Liner.ai | Creates classification models from your data | [🔗](https://liner.ai/)|
 | Phind | LLM-powered search engine for developers and technical questions | [🔗](https://phind.com/)|
 | Promptable.ai | the ultimate workspace for prompt engineering | [🔗](https://promptable.ai/)|
 | Suppress.js | Building or augmenting backend with AI | [🔗](https://github.com/velocitatem/suppress) |


### PR DESCRIPTION
Adds [liner.ai](https://liner.ai/) to the list of developer tools. This can be used to create classification models for images/audio/text from your datasets. Liner.ai then provides python examples of how to use the model. 