### PR TITLE
Add AI Conference Deadline to "Research Tools" list

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ Curated list of top AI Tools.
 | MuckBrass | Find & Validate Startup Ideas | [🔗](https://www.muckbrass.com) |
 | Phind | An AI search engine, using multi-step reasoning to find the answer & generative UI to present it in a beautiful and interactive way.| [🔗](https://www.phind.com/)|
 | DeepResearch-Agent | An OpenAI-like DeepResearch agent that plans and thinks, equipped with a beautiful frontend (UI). | [🔗](https://github.com/Parveshiiii/Deepresearch-Agent) |
+|AI Conference Deadline | AI/ML conference deadline tracker| [🔗](https://www.aiconferenceddl.com/)|
 
 ## Geospatial
 


### PR DESCRIPTION
Hi!

I’d like to add a free tool: [AI Conference Deadline](https://www.aiconferenceddl.com/) to the AI research tools list.

It is a simple AI conference deadline tracker designed for researchers in different fields: AI/ML/Robotics. It allows users to:

- Track major AI and machine learning conference paper submission deadlines
- Quickly access official conference websites from a single list
- Plan submissions without accounts, setup, or unnecessary features
