### PR TITLE
Add PM Skills to Productivity section

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Curated list of top AI Tools.
 | Promptly | Discover, create and share powerful prompts | [🔗](https://searchpromptly.com/) |
 | Spell | Spell is the AI alternative to Google Docs | [🔗](https://spellapp.com) |
 | Kosmik | AI moodboarding platform | [🔗](https://www.kosmik.app) |
+| PM Skills | 24 AI agent skills for product managers across the full product lifecycle | [🔗](https://github.com/product-on-purpose/pm-skills) |
 | Magic Potion | Visual AI Prompt Editor | [🔗](https://www.magicpotion.app) |
 | EKHOS AI | EKHOS AI is a powerful speech-to-text software that accurately transcribes audio and video files, supports real-time recording and transcription, and a built-in proofreading editor. | [🔗](https://ekhos.ai/) |
 | 3D House Planner | AI-Powered 3D Floor Plan Generation from Images | [🔗](https://3dhouseplanner.com/) |


### PR DESCRIPTION
## Summary

Adds [PM Skills](https://github.com/product-on-purpose/pm-skills) to the **Productivity** section.

PM Skills is an open-source collection of 24 AI agent skills for product managers, covering the full product lifecycle from discovery through delivery. It follows the [agentskills.io specification](https://agentskills.io/specification) and is Apache 2.0 licensed.

## Changes

- Added one entry to the Productivity table in `README.md`