### PR TITLE
Add AI Interview Coach for Engineering Leaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Curated list of top AI Tools.
 | TaxTools AI | AI Tax Tools | [🔗](https://taxtools.ai/cn) |
 
 ## Education
+- [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers. 130+ role-specific questions, STAR-format scoring, and 3 interviewer personas.
 
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |


### PR DESCRIPTION
## Add AI Interview Coach for Engineering Leaders

[AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice built for software engineers and engineering managers. 130+ role-specific questions, STAR-format scoring across 6 dimensions, probing follow-ups, and 3 interviewer personas (Startup CTO, Big Tech VP, Scale-up Director). Free first question.