### PR TITLE
Add AI API Cost Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ Curated list of top AI Tools.
 | Price Per Token | Compare LLM API pricing across 300+ models with token counters and benchmarks | [🔗](https://pricepertoken.com/) |
 | TestSprite | The most powerful AI testing tool for testing, fixing, and validating your software in one automated flow. | [🔗](https://www.testsprite.com/) |
 | Omnara | Command Center for AI Coding Agents. | [🔗](https://www.omnara.com/) |
+| AI API Cost Calculator | Free tool to estimate and compare API token costs across 23 tools and 7 models .. | [🔗](https://aiagentsbuzz.com/tools/ai-cost-calculator/) |
 
 
 ## Gaming, 3D, Motion


### PR DESCRIPTION
Hi! I'd like to add the AI API Price Calculator to the list.

It's a free, no-signup tool that lets developers paste their actual prompt, 
select output size, toggle reasoning/thinking tokens (o3, Claude, Gemini, 
DeepSeek R1, Grok 4), and compare costs across 23 models from 7 providers. 
Also shows monthly cost projections.

Happy to adjust placement or wording. Thanks for maintaining this list!