### PR TITLE
Add DoaCam to Conversational AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Curated list of top AI Tools.
 | DoNotPay | the world's first robot lawyer | [🔗](https://donotpay.com/)|
 | Replika | an AI companion | [🔗](https://replika.ai/)|
 | Breezy | Real-time AI voice chat with unique characters | [🔗](https://talkbreezy.com/)|
+| DoaCam | AI video companion with a 3D avatar that sees you through your camera, talks in real time, and remembers you | [🔗](https://doacam.com)|
 | AICamp | ChatGPT for Teams | [🔗](https://aicamp.so/)
 | Netwrck | AI Character Chat Social Network, saying "Appears" makes the AI make Art. | [🔗](https://netwrck.com/)|
 | Claude | Talk to Claude, an AI assistant from Anthropic. | [🔗](https://claude.ai/)|


### PR DESCRIPTION
## Summary

Adds [DoaCam](https://doacam.com) to the **Conversational AI** section.

DoaCam is an AI video companion with a 3D avatar that sees you through your camera, talks in real time, and remembers you across sessions. Runs entirely in the browser with no sign-up required.

## Changes
- Added one row to the Conversational AI table following the existing format