### PR TITLE
Add GEOScore AI to Sales/Marketing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,7 @@ Curated list of top AI Tools.
 | Gro | AI Sales Agent for B2B Lead Generation | [🔗](https://thegro.ai/) |
 | RepuAI | AI visibility scoring and brand monitoring for AI search engines | [🔗](https://repuai.live/en) |
 | Reelify AI | Free & Unlimited AI video clipper to turn long videos into viral Shorts/Reels. | [🔗](https://reelifyclips.com/) |
+| GEOScore AI | Free AI search visibility scanner. Checks 9 GEO signals across 11 AI platforms and provides actionable fixes. | [🔗](https://geoscoreai.com) |
 
 
 ## Productivity


### PR DESCRIPTION
## What is GEOScore AI?
[GEOScore AI](https://geoscoreai.com) is a free diagnostic tool that scans your website's readiness for AI search engines (ChatGPT, Perplexity, Claude, Gemini). It provides a 0-100 readiness score across 9 key signals including llms.txt, schema markup, robots.txt, and crawl access.

**Key features:**
- Free instant scan — no signup required
- 9-point diagnostic across 50+ pages
- Covers 11 AI platforms
- Pro Fix Package ($29) with deploy-ready code fixes
- Free tools: AI Robots.txt Generator & AI Crawler Access Checker
- 2,500+ websites scanned

**Website:** https://geoscoreai.com