### PR TITLE
Add Typer - free local AI chat for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Curated list of top AI Tools.
 | Pleasuredomes | AI Image and chatbot | [🔗](http://pleasuredomes.ai/) |
 | ChatSweetie | Free AI Girlfriend Chat | [🔗](https://chatsweetie.ai/) |
 | Venice | Private and uncensored conversational AI | [🔗](https://venice.ai/) |
+| Typer | Free local AI chat for Mac — runs on-device, no account, no cloud, no ads | [🔗](https://typer.space)|
 
 ## Design
 


### PR DESCRIPTION
Typer is a free local AI chat app for macOS (Apple Silicon) that runs entirely on-device with no account, no cloud, and no ads. It supports offline chat and on-device web search.

It fits the Conversational AI section as a private, local alternative to cloud-based AI chat tools.