### PR TITLE
Add Burn 451 to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Curated list of top AI Tools.
 | LocalChat.app | Local-first MacOS AI application - 100% Private, Works Fully Offline | [🔗](https://www.localchat.app/) |
 | Ration | AI-Powered Pantry & Meal Planning Platforms | [🔗](https://ration.mayutic.com/) |
 | Consul | Executive Assistant That Runs Your Calendar, Inbox & Scheduling | [🔗](https://consul.so/) |
+| Burn 451 | AI-native read-later with 24h burn timer; saved articles become a permanent knowledge vault your AI agents can query via MCP | [🔗](https://burn451.cloud/?ref=top-ai-tools) |
 
 ## Search Engines & Tools
 


### PR DESCRIPTION
Adding Burn 451 — an AI-native read-later and knowledge vault for people who save more than they read.

Why it fits `## Productivity`:
- Solves the saved-but-never-read problem with a 24-hour burn timer that forces daily triage
- AI digest summarizes your reading queue on save (not just individual articles)
- Ships a 26-tool MCP server so Claude, Cursor, and other AI agents can query your vault in real time
- Free today — iOS app + Web + Chrome extension, no hidden paywall

Format follows the existing table style — `| Tool | Used for | Link |` with a one-line description.