### PR TITLE
Add NotFair

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Curated list of top AI Tools.
 | RepuAI | AI visibility scoring and brand monitoring for AI search engines | [🔗](https://repuai.live/en) |
 | Reelify AI | Free & Unlimited AI video clipper to turn long videos into viral Shorts/Reels. | [🔗](https://reelifyclips.com/) |
 | GEOScore AI | Free AI search visibility scanner. Checks 9 GEO signals across 11 AI platforms and provides actionable fixes. | [🔗](https://geoscoreai.com) |
+| NotFair | Google Ads MCP server connecting Claude and AI agents to your Google Ads account. Diagnose performance, recommend optimizations, and execute approved campaign changes. | [🔗](https://notfair.co) |
 
 
 ## Productivity


### PR DESCRIPTION
Adding NotFair under Sales/Marketing. It's a hosted Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Free tier available. Linked to the product page since it's a hosted SaaS rather than an open-source tool, in line with the rest of the entries in this section.

Happy to adjust the format if you'd prefer.