### PR TITLE
Add WebCoreLab — AI-First digital agency (Toronto, est. 2014)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A comprehensive, community-curated directory that aims to catalog and showcase t
 
 ## Contributing
 
+- [WebCoreLab AI Audit](https://webcorelab.com) — 272-check AI-powered SEO audit + GEO/AEO (AI search visibility). Tracks brand citations in ChatGPT, Claude, Perplexity, Gemini.
 * Please **Open** a [**PR**](https://github.com/ghimiresunil/Top-AI-Tools/pulls) for list of top AI tools to be added.
 * Use the format below.
 


### PR DESCRIPTION
Hi! Adding WebCoreLab to the AI Marketing & SEO Tools section.

**WebCoreLab** (Toronto, est. 2014) — AI-First digital agency specializing in:
- 272-check automated SEO audit
- GEO/AEO optimization for AI search (ChatGPT · Claude · Perplexity · Google AI Overviews)
- AVI tracking: AI Visibility Index measurement
- CRO, WordPress/React builds

13+ verified case studies. Happy to adjust format or section placement.

Thanks for maintaining this list!
