### PR TITLE
Add Punch Needle Generator to Art & Creativity

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Curated list of top AI Tools.
 | PolyGlyph | AI-powered SVG generation and editing tool. Generate vector graphics from text prompts and edit in a browser-based vector editor. | [🔗](https://polyglyph.io/)
 | AI Photo Editor | Free AI Photo Editor & Image Generator Online. Edit, Enhance & Create Stunning Photos with AI-Powered Tools.  | [🔗](https://aiphotoeditor.io/)
 | Musiv | AI music video generation from audio tracks | [🔗](https://musiv.ai/) |
+| Punch Needle Generator | AI-powered punch needle embroidery pattern generator with color-coded yarn maps. Generates patterns from text prompts or image uploads, exports PDF/PNG/SVG. | [🔗](https://www.punchneedle.co.il/en) |
 
 ## Conversational AI
 


### PR DESCRIPTION
Adds Punch Needle Generator under **Art & Creativity**.

- **Name:** Punch Needle Generator
- **URL:** https://www.punchneedle.co.il/en
- **Description:** AI-powered punch needle embroidery pattern generator with color-coded yarn maps. Generates patterns from text prompts or image uploads, exports PDF/PNG/SVG.

I'm the maintainer of the tool. Single entry, follows the table format used in the section.