### PR TITLE
Add GPT for Sheets to productivity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Curated list of top AI Tools.
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |
 | GPT for Sheets and Docs | integrate GPT in your everyday tools | [🔗](https://workspace.google.com/marketplace/app/gpt_for_sheets_and_docs/677318054654) |
+| GPT for Sheets | AI for Google Sheets to generate formulas, classify rows, translate content, and automate spreadsheet workflows at scale. | [🔗](https://docgpt.ai/gpt-for-sheets) |
 | SummaryTube | Youtube Video Summarizer with AI, extract transcripts & key moments | [🔗](https://summarytube.com/) |
 | Lex | Web based AI writing tool | [🔗](https://lex.page/) |
 | Codeflash | Ship Blazing-Fast Python Code — Every Time. | [🔗](https://www.codeflash.ai/) 


### PR DESCRIPTION
Adds GPT for Sheets as a Google Sheets-focused AI productivity tool.\n\nWhy it fits:\n- direct fit for the productivity section\n- complements the existing Sheets/Docs marketplace listing with a dedicated Sheets workflow page\n- keeps description short and factual