### PR TITLE
Add AICareerPivot - AI career transition strategist

### DIFF
--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ Curated list of top AI Tools.
 | MyLooks.AI | Find out how hot you are & become hotter! | [🔗](https://mylooks.ai) |
 | goDeskless | Optimize field service and boosts customer satisfaction. | [🔗](https://godeskless.com/) |
 | ezJobs | Automated job search and applications | [🔗](https://getezjobs.com/) |
+| AICareerPivot | AI-powered career transition strategist that builds personalized pivot roadmaps based on skills, finances, and life constraints | [🔗](https://ai-career-pivot.com) |
 | DecorAI | Generate Interior and Exterior Ideas in Seconds | [🔗](https://decorai.io) |
 | Foundy.com | Sell your business at a higher valuation or find quality acquisitions with Foundy's AI and expert support. | [🔗](https://foundy.com) |
 | Build Club | Community + education for AI builders | [🔗](https://www.buildclub.ai) |


### PR DESCRIPTION
## Summary

Adding [AICareerPivot](https://ai-career-pivot.com) to the Others section.

AICareerPivot is an AI-powered career transition strategist that builds personalized pivot roadmaps based on your skills, finances, and life constraints. Generates concrete 6-month to 2-year action plans with milestone tracking and AI coaching.

Placed alongside similar career/job tools like ezJobs, scale.jobs, and Interviews Chat.