### PR TITLE
Add Clipy (AI screen recorder) to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@ Curated list of top AI Tools.
 | Burn 451 | AI-native read-later with 24h burn timer; saved articles become a permanent knowledge vault your AI agents can query via MCP | [🔗](https://burn451.cloud/?ref=top-ai-tools) |
 | Podtastic | Podtastic is a podcast player powered by Pod-telligence | [🔗](https://podtastic.app/) |
 | Video to Text | Turn any video or audio into clean text in minutes | [🔗](https://video2text.net/) |
+| Clipy | Free AI screen recorder — record and share an instant link, with an AI summary, searchable transcript, and auto-chapters on every recording; no signup required to watch | [🔗](https://clipy.online/?ref=Top-AI-Tools) |
 
 ## Search Engines & Tools
 


### PR DESCRIPTION
Adds [Clipy](https://clipy.online) to the **Productivity** table.

Clipy is a free AI screen recorder — record your screen and share an instant link, with an AI summary, searchable transcript, and auto-chapters on every recording (no signup required to watch).

Thanks for maintaining this list!