### PR TITLE
Add Citely to Research Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Curated list of top AI Tools.
 | DeepResearch-Agent | An OpenAI-like DeepResearch agent that plans and thinks, equipped with a beautiful frontend (UI). | [🔗](https://github.com/Parveshiiii/Deepresearch-Agent) |
 |AI Conference Deadline | AI/ML conference deadline tracker| [🔗](https://www.aiconferenceddl.com/)|
 | CiteMe | AI-powered academic citation generator. Searches 11+ databases and formats references in 40+ citation styles. | [🔗](https://citeme.app)|
+| Citely | AI citation checker and academic source finder for verifying references and claims. | [🔗](https://citely.ai/)|
 | 8bit Concepts | Free AI research papers on enterprise AI adoption and governance | [🔗](https://8bitconcepts.com)|
 
 ## Geospatial


### PR DESCRIPTION
Added Citely to the Research Tools section.

Citely is relevant here because it combines an AI citation checker with an academic source finder, helping students and researchers verify references and find supporting sources for claims.

Checklist:
- [x] Added one tool only
- [x] Tool link is valid
- [x] Placed in the Research Tools category
- [x] No unrelated changes included