### PR TITLE
Add Auferet to Gaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Curated list of top AI Tools.
 | Imagine 3D (by Luma AI) | tool for prototyping 3D objects with text | [🔗](https://captures.lumalabs.ai/imagine)|
 | move.ai | AI-powered real-time motion capture | [🔗](https://www.move.ai/)|
 | Inworld AI | create any character you can imagine | [🔗](https://inworld.ai/)|
+| Auferet | AI game master for solo text adventures and tabletop RPGs, with long-term story memory and your own uploaded lore | [🔗](https://auferet.com/)|
 | Seele AI | No-code AI game maker for creating playable 2D/3D games from text prompts | [🔗](https://www.seeles.ai/)|
 | Scenario | creating AI-generated game assets | [🔗](https://www.scenario.gg/)|
 


### PR DESCRIPTION
Adds **Auferet** to the Gaming section.

Auferet is an AI game master for solo text adventures and tabletop-style RPGs. It keeps long-term memory of your story and can read your own uploaded lore, and runs in the browser and on Android. Row follows the existing table format.
