### PR TITLE
Fix 'slash' in link for RemoveGlassesGlare in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Curated list of top AI Tools.
 | JustDance | AI Dance Video Generator - Make Anything Dance. | [🔗](https://justdance.cc/)
 | AI Photo Editor | Free AI Photo Editor & Image Generator Online. Edit, Enhance & Create Stunning Photos with AI-Powered Tools.  | [🔗](https://aiphotoeditor.io/)
 | Musiv | AI music video generation from audio tracks | [🔗](https://musiv.ai/) |
-| RemoveGlassesGlare | Remove glare and reflections from glasses in photos | [🔗](https:/removeglassesglare.com) |
+| RemoveGlassesGlare | Remove glare and reflections from glasses in photos | [🔗](https://removeglassesglare.com) |
 | Punch Needle Generator | AI-powered punch needle embroidery pattern generator with color-coded yarn maps. Generates patterns from text prompts or image uploads, exports PDF/PNG/SVG. | [🔗](https://www.punchneedle.co.il/en) |
 
 ## Conversational AI


### PR DESCRIPTION
There was a '/' missing in 'https://', so the link was not accurate. Fixed it now. Thanks.