### PR TITLE
docs: add GPT for Gmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ Curated list of top AI Tools.
 | aiPDF | The most advanced AI document assistant | [🔗](https://aipdf.ai) |
 | Myriad | Build and fine-tune AI content prompts for writing anything, from long-form posts to ads and emails, by mixing and matching rules. | [🔗](https://www.namepepper.com/free-tools/ai-content-prompt-tool) |
 | Emilio | Stop drowning in emails - Emilio prioritizes and automates your email, saving 60% of your time | [🔗](https://getemil.io?ref=ghimiresunil-top-ai-tools) |
+| GPT for Gmail | AI email assistant for Gmail to draft, improve, summarize, translate, and reply to emails faster. | [🔗](https://docgpt.ai/ai-email-assistant/) |
 | Chatpdf.so | Chatpdf.so is an AI based chat tool designed to chat with PDF. | [🔗](https://chatpdf.so) |
 | ReportGPT | Elevate your document writing by harnessing the power of AI and experience the seamless creation of documents. | [🔗](https://report-gpt.io) |
 | Recurrr | Send recurring emails | [🔗](https://recurrr.com) |


### PR DESCRIPTION
## Summary
- Add GPT for Gmail as an AI email assistant
- Keep the entry in the existing table format

GPT for Gmail helps Gmail users draft, improve, summarize, translate, and reply to emails faster.