### PR TITLE
Add AnswerLens to Sales/Marketing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ Curated list of top AI Tools.
 
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |
+| AnswerLens | Audits public B2B SaaS page evidence for AI search and SEO, then maps gaps in pricing, comparison, docs, proof, and trust pages into a fix plan | [🔗](https://app.sfdj.net/) |
 | Autorank | AI SEO Tool | [🔗](https://www.getautorank.ai)|
 | ChampSignal.com | Competitor Monitoring That Doesn't Suck | [🔗](https://champsignal.com)|
 | Choppity.com | Instantly turn long podcast videos into short TikToks | [🔗](https://www.choppity.com/)|


### PR DESCRIPTION
## Summary
- Add AnswerLens to the Sales/Marketing table.
- Keep the entry to one factual row in the existing format.

## Fit
AnswerLens audits public B2B SaaS page evidence for AI search and SEO, then maps gaps in pricing, comparison, docs, proof, and trust pages into a fix plan.

I am connected to AnswerLens, so I kept the wording bounded and avoided outcome claims.