### PR TITLE
Add Interior Design Clinic to Design section

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Curated list of top AI Tools.
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |
 | Interior AI | interior design mockups and virtual staging | [🔗](https://interiorai.com/)|
+| Interior Design Clinic | Redesign any room from a single photo — photorealistic AI redesigns anchored to your real space, with before/after, day/night lighting, and shop-the-look | [🔗](https://interiordesignclinic.com/) |
 | AI Virtual Staging | AI powered virtual staging | [🔗](https://www.aivirtualstaging.net/)|
 | stockimg.ai  | AI-powered designs | [🔗](https://stockimg.ai/)|
 | Brand Mark | Generating brand logos | [🔗](https://brandmark.io/)|


### PR DESCRIPTION
Adds Interior Design Clinic to the Design category.

- Tool: Interior Design Clinic (https://interiordesignclinic.com/)
- What it does: AI app that redesigns any room from a single photo — photorealistic redesigns anchored to your actual space (not templates), with before/after comparison, day/night lighting previews, and shop-the-look furniture matching.
- Placed alphabetically-neutral at the end of the Design section, following the existing `| Tool | Used for | [🔗](link) |` format.