### PR TITLE
Add Aural to Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Curated list of top AI Tools.
 
 ## Education
 - [AI Interview Coach](https://em-tools.io/interview-prep) - Voice-based AI behavioral interview practice for engineering managers and software engineers. 130+ role-specific questions, STAR-format scoring, and 3 interviewer personas.
+- [Aural](https://github.com/1146345502/aural-oss) - Open-source, self-hostable AI interview platform for voice, chat, and video interviews with adaptive follow-ups and automated reports.
 
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |


### PR DESCRIPTION
Adds Aural to the Education section as an open-source, self-hostable AI interview platform.

Aural supports voice, chat, and video interviews with adaptive follow-ups and automated reports.

Project: https://github.com/1146345502/aural-oss

Affiliation: I am the project maintainer. I checked the list for duplicates and followed the existing entry format.