### PR TITLE
Add Chat Organizer to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ Curated list of top AI Tools.
 | VideoFaceSwap | Free Online Face Swapping Tool | [🔗](https://videofaceswap.io/) |
 | Scribbl | AI Meeting Notes | [🔗](https://www.scribbl.co) |
 | Convo | AI meeting copilot that gives you real-time suggestions, talking points, and answers during live calls | [🔗](https://www.itsconvo.com) |
+| Chat Organizer | Free Chrome extension that auto-sorts Claude.ai and ChatGPT chats into projects in one click, using keyword matching and AI | [🔗](https://chromewebstore.google.com/detail/bipbaacophbcpboieghjoigjlbemchcm) |
 | Voice Command | VOICE COMMANDS and VOICE TYPING anywhere on the web | [🔗](https://myextension.store/voice-command/) |
 | YobiYoba | Yobiyoba offers advanced speech-to-text services and an API for automatic transcription, real-time audio processing, audio-text alignment, and lexicon enhancement, complemented by a powerful and intuitive editor for seamless transcription refinement. | [🔗](https://www.yobiyoba.com/en/)
 | Bricks | The AI Spreadsheet We've All Been Waiting For | [🔗](https://www.thebricks.com/) |


### PR DESCRIPTION
Chat Organizer is a free Chrome extension that auto-sorts Claude.ai and ChatGPT chats into projects in one click (keyword matching plus AI for ambiguous titles, full preview before anything moves). No API key or account needed.

- Store: https://chromewebstore.google.com/detail/bipbaacophbcpboieghjoigjlbemchcm
- Site: https://chat-organizer.com

One row added to the Productivity table, following the format in the README.