### PR TITLE
Add Better Agent to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Curated list of top AI Tools.
 | GitPoet | Git commit message generator (based on your changes) with a VSCode extension | [🔗](https://www.gitpoet.dev/)|
 |AskCommand|Generate Unix commands from text automatically|[🔗](https://www.askcommand.cppexpert.online/)|
 | Shire | Open-source persistent workspaces for AI agent teams with inter-agent mailboxes, shared drive, and context preservation. Supports Claude Code, OpenCode, Pi Agent and more. | [🔗](https://github.com/victor36max/shire)|
+| Better Agent | Persistent workspace for Claude, Codex, and Gemini coding-agent sessions with delegation, parallel forks, approvals, and restart recovery. | [🔗](https://github.com/ofekron/better-agent)|
 | Shotstack Workflows | No-code, automation workflow tool for building Generative AI media applications |[🔗](https://shotstack.io/product/workflows/)|
 | text-generator.io AI Text Generator | Open Source Vision language models and web crawlers to understand any links in prompts given. API for developers and special support for AI autocomplete. | [🔗](https://text-generator.io) |
 | Code to Flow | Visualize, Analyze, and Understand Your Code flow. Turn Code into Interactive Flowcharts with AI. Simplify Complex Logic Instantly. | [🔗](https://codetoflow.com) |


### PR DESCRIPTION
Adds Better Agent to the Developer table using the repository format. The entry describes its persistent Claude, Codex, and Gemini coding-agent sessions, delegation, parallel work, approvals, and restart recovery.

Disclosure: I maintain Better Agent. It is source-available and free for non-commercial use; commercial use requires permission. This contribution was prepared with Codex assistance and reviewed before submission.