### PR TITLE
Add Hellomatik

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,7 @@ Curated list of top AI Tools.
 | Rosie | AI Phone Answering Service | [🔗](https://heyrosie.com/) |
 | Vidocu | Turn screen recordings into professional videos and documentation | [🔗](https://vidocu.ai/) |
 | AnveVoice | AI voice agent for websites — trains on your content, navigates pages, fills forms, books appointments in 50+ languages with <700ms latency | [🔗](https://anvevoice.app) |
+| Hellomatik | AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web. | [🔗](https://hellomatik.com) |
 
 ## Phone Calls
 


### PR DESCRIPTION
Adds **Hellomatik** — an AI agent platform that turns a company's own knowledge into agents that answer, sell and book across WhatsApp, email and web. Single entry matched to the section format. Thanks for the list!