### PR TITLE
Add AI Router to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Curated list of top AI Tools.
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |
 | AI/ML API | 200+ AI models thorugh on API. ChatGPT, Sonnet, Gemini, Llama, and even many video and image-gen models, all in one place. | [🔗](https://aimlapi.com/?utm_source=top-ai-tools&utm_medium=github&utm_campaign=integration)|
+| AI Router | Hosted OpenAI-compatible API relay for developer and coding-agent workflows; supports personal API keys, per-key usage visibility, and model discovery through authenticated `/v1/models`. | [🔗](https://ai-router.dev) |
 | Chat Data Prep | data transformation using plain english | [🔗](https://www.akkio.com/chat-data-prep)|
 | Codeium | free AI powered code completion | [🔗](https://www.codeium.com/)|
 | Capacity | Create fullstack web applications using AI | [🔗](https://capacity.so/)|


### PR DESCRIPTION
## Summary

- Adds AI Router to the existing Developer table using the repository's three-column format.
- Uses the English product page for this English-language entry.

Disclosure: I operate AI Router. It is independently operated and not affiliated with OpenAI.

The description is limited to public, testable integration facts: OpenAI-compatible API access, personal API keys, usage visibility, and authenticated `/v1/models` discovery. It intentionally makes no claim about free credits, price, a fixed model list, data retention, or reliability.

Verification: `https://ai-router.dev` returns a public page and `https://api.ai-router.dev/v1/models` returns `401` without a key, confirming an authentication-protected live endpoint.