### PR TITLE
Add Videosays to video transcription tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ Curated list of top AI Tools.
 | Video Transcriber | Transcribe Video to Text Online Free | [🔗](https://videotranscriber.ai/) |
 | Audio Converter | Convert Audio to Text Online Free | [🔗](https://audioconverter.ai/) |
 | TikTok Transcript | Extract TikTok subtitles and download transcripts in SRT or TXT. | [🔗](https://tiktoktranscript.org/) |
+| Videosays | Turn public social video links into transcripts and timestamped subtitles | [🔗](https://videosays.com/) |
 | My Passion AI | AI-powered quiz to find your passion career path | [🔗](https://mypassion.ai) |
 | Worklytics | Analytics on AI and Productivity | [🔗](https://www.worklytics.co/) |
 | Voibe | Fast, private, on device AI voice dictation app for Mac | [🔗](https://www.getvoibe.com) |


### PR DESCRIPTION
## Summary

Adds Videosays next to the existing video transcription tools. Videosays converts supported public social video links into transcripts and timestamped subtitles, with TXT, SRT, and VTT export.

## Verification

- Confirmed https://videosays.com/ is live
- Followed the existing README table format
- Added one neutral product entry