### PR TITLE
Add Harku YouTube Transcript Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Curated list of top AI Tools.
 | Type Think AI | Your Gateway to Multiple AI Models | [🔗](https://typethinkai.com/) |
 | Smmry | Summarize Long Content Into Clear Insights | [🔗](https://smmry.com/) |
 | TranscribeTube | Transcribe youtube video, spotify podcast to text free & AI-ready formats | [🔗](https://www.transcribetube.com/?ref=Top-AI-Tools) |
+| Harku YouTube Transcript Generator | Convert YouTube videos into timestamped text with 60+ languages and TXT/SRT/VTT/DOCX exports | [🔗](https://harku.io/tools/youtube-to-text) |
 | ResumeBoostAI | Generate professional resumes using AI | [🔗](https://resumeboostai.com/) |
 | Alt Text Generator AI | Generate alt text for images using AI | [🔗](https://alttextgeneratorai.com/) |
 | PropertyListingsAI | Generate real estate listings using AI | [🔗](https://propertylistingsai.com/) |


### PR DESCRIPTION
Adding **Harku YouTube Transcript Generator** to the Productivity section.

- **Tool:** Harku YouTube Transcript Generator
- **Used For:** Convert YouTube videos into timestamped text with 60+ languages and TXT/SRT/VTT/DOCX exports
- **Link:** https://harku.io/tools/youtube-to-text

This follows the existing `| Tools | Used For | [🔗](Link) |` table format. The live product page was checked and `git diff --check` passes.
