### PR TITLE
docs: add Faceless Reels to Art & Creativity

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Curated list of top AI Tools.
 | Punch Needle Generator | AI-powered punch needle embroidery pattern generator with color-coded yarn maps. Generates patterns from text prompts or image uploads, exports PDF/PNG/SVG. | [🔗](https://www.punchneedle.co.il/en) |
 | PixMira AI | AI photo editor and image generator for editing, generating, and transforming images with prompts. | [🔗](https://pixmira.ai) |
 | Picovix | Free AI consistent character & virtual model generator — keep the same face across unlimited scenes from one selfie, no signup | [🔗](https://www.picovix.app/) |
+| Faceless Reels | Turn one topic into a voiced, captioned faceless video for TikTok, Reels, and Shorts. | [🔗](https://facelessreels.video/) |
 
 ## Conversational AI
 


### PR DESCRIPTION
Adds [Faceless Reels](https://facelessreels.video/) — an AI faceless video generator. Pick a topic and a workflow (storytelling, doodle explainer, stickman animation, open-source shorts) and it writes the hook and script, generates the AI voiceover, captions, visuals and music, then renders a 9:16 video for TikTok, Instagram Reels and YouTube Shorts. Freemium, free credits on signup.

Disclosure: I am part of the team building this product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)