### PR TITLE
Update PM Skills entry: 24 skills is stale, the library now ships 68

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Curated list of top AI Tools.
 | Promptly | Discover, create and share powerful prompts | [🔗](https://searchpromptly.com/) |
 | Spell | Spell is the AI alternative to Google Docs | [🔗](https://spellapp.com) |
 | Kosmik | AI moodboarding platform | [🔗](https://www.kosmik.app) |
-| PM Skills | 24 AI agent skills for product managers across the full product lifecycle | [🔗](https://github.com/product-on-purpose/pm-skills) |
+| PM Skills | 68 AI agent skills for product managers across the full product lifecycle, plus sub-agents and multi-skill workflows | [🔗](https://github.com/product-on-purpose/pm-skills) |
 | Magic Potion | Visual AI Prompt Editor | [🔗](https://www.magicpotion.app) |
 | EKHOS AI | EKHOS AI is a powerful speech-to-text software that accurately transcribes audio and video files, supports real-time recording and transcription, and a built-in proofreading editor. | [🔗](https://ekhos.ai/) |
 | 3D House Planner | AI-Powered 3D Floor Plan Generation from Images | [🔗](https://3dhouseplanner.com/) |


### PR DESCRIPTION
Updates the existing PM Skills entry, which is out of date.

The entry says 24 skills. The library has since grown to 68 and is on v2.31.1, so this refreshes the description to match and notes the sub-agents and multi-skill workflows it now ships.

This edits an existing row rather than adding one, so the total tool count is unchanged.

- Repo: https://github.com/product-on-purpose/pm-skills
- 68 skills, 6 sub-agents, 12 workflows, 200+ sample outputs
- Apache 2.0, follows the agentskills.io specification
