### PR TITLE
Add Mydentify AI Product Read to Sales/Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Curated list of top AI Tools.
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |
 | AnswerLens | Audits public B2B SaaS page evidence for AI search and SEO, then maps gaps in pricing, comparison, docs, proof, and trust pages into a fix plan | [🔗](https://app.sfdj.net/) |
+| Mydentify AI Product Read | Reads a public product homepage with AI to report inferred category, audience, value, and unclear facts | [🔗](https://mydentify.com/tools/what-does-ai-think-my-product-is) |
 | Autorank | AI SEO Tool | [🔗](https://www.getautorank.ai)|
 | ChampSignal.com | Competitor Monitoring That Doesn't Suck | [🔗](https://champsignal.com)|
 | Choppity.com | Instantly turn long podcast videos into short TikToks | [🔗](https://www.choppity.com/)|


### PR DESCRIPTION
## Summary

Adds one factual row for Mydentify AI Product Read to the existing Sales/Marketing table.

The tool reads bounded public homepage evidence with an AI model and reports the inferred product category, audience, value, confidence, and unclear facts. The exact linked tool requires a paid Mydentify account; this contribution makes no free-use or ranking claim.

## Disclosure

I maintain Mydentify and am submitting this tool directly.