### PR TITLE
Add Resume Roaster to HR section

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,7 @@ Curated list of top AI Tools.
 | Candor | AI-Powered 360-Degree Feedback | [🔗](https://www.candor.so/) |
 | SimplePerf | A simple, guided 360° performance review tool made for small teams | [🔗](https://buddieshr.com/simpleperf) |
 | AI Dev Jobs | AI/ML job board with public REST API for programmatic job search | [🔗](https://aidevboard.com)|
+| Resume Roaster | AI-powered resume critique with ATS scoring - upload your resume, get brutally honest feedback and keyword gap analysis against any job description. | [🔗](https://resume.roastlabai.com) |
 
 ## Others
 


### PR DESCRIPTION
Hi! I would like to add Resume Roaster to the HR section.

**Resume Roaster** (https://resume.roastlabai.com) is an AI-powered resume analysis tool that:
- Provides brutally honest AI critique of your resume
- Scores your resume against ATS (Applicant Tracking Systems)
- Identifies keyword gaps between your resume and job descriptions
- Gives actionable improvement suggestions

It fits naturally alongside other HR tools in this section. Thanks for maintaining this great list!