### PR TITLE
Add IdeaHunter

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ Curated list of top AI Tools.
 | Competitor Research | AI tool to help companies track their competitors | [🔗](https://www.competitoresearch.com/) |
 | Compass | AI-driven answers to SaaS research questions | [🔗](https://www.getwhys.io/compass) |
 | MuckBrass | Find & Validate Startup Ideas | [🔗](https://www.muckbrass.com) |
+| IdeaHunter | AI research for demand-backed app and micro-SaaS ideas | [🔗](https://ideahunter.today) |
 | Phind | An AI search engine, using multi-step reasoning to find the answer & generative UI to present it in a beautiful and interactive way.| [🔗](https://www.phind.com/)|
 | DeepResearch-Agent | An OpenAI-like DeepResearch agent that plans and thinks, equipped with a beautiful frontend (UI). | [🔗](https://github.com/Parveshiiii/Deepresearch-Agent) |
 |AI Conference Deadline | AI/ML conference deadline tracker| [🔗](https://www.aiconferenceddl.com/)|


### PR DESCRIPTION
Adds IdeaHunter to Research Tools. Disclosure: submitted by an authorized agent for IdeaHunter. Verified canonical URL returns HTTP 200. The entry follows the table format requested in the repository. No payment, CAPTCHA, email verification, phone, address, or reciprocal backlink required.