### PR TITLE
Add Summoned Games to Gaming, 3D, Motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Curated list of top AI Tools.
 | Seele AI | No-code AI game maker for creating playable 2D/3D games from text prompts | [🔗](https://www.seeles.ai/)|
 | Scenario | creating AI-generated game assets | [🔗](https://www.scenario.gg/)|
 | MeshGPT | AI-Powered 3D Model Generation & Optimization | [🔗](https://meshgpt.io/)|
+| Summoned Games | Build browser games by describing them to an MCP coding agent; hosting, leaderboards, saves and multiplayer are included | [🔗](https://summoned.games)|
 
 ## Sales/Marketing
 


### PR DESCRIPTION
Adds Summoned Games to the Gaming, 3D, Motion table.

You connect a coding agent (Claude Code, Codex, anything that speaks MCP) to the platform, describe the game you want, and the agent writes it while the platform builds, reviews and hosts it. Published games run in the browser, free and without an account, and get leaderboards, save data and multiplayer for up to 16 players.

Closest existing entry is Seele AI, though that one is no-code text-to-game and this is aimed at people already working through a coding agent.

Happy to move it if you would rather see it in a different category.