### PR TITLE
Add SEELE TV to art and creativity tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Curated list of top AI Tools.
 | PDFtoVideo | Convert PDF & Any Contents to Video Online Free | [🔗](https://pdftovideo.ai/)
 | OpenCreator | All-in-one AI workspace for creating product visuals with workflow automation | [🔗](https://opencreator.ai/)
 | Somny | AI character generator for creating personalized images and videos from your own likeness. | [🔗](https://www.somny.com/)
+| SEELE TV | Cinematic AI video studio with scene consistency and shot-level camera control. | [🔗](https://seele.tv/) |
 | MaxVideoAI | Multi-engine AI video generation hub (Sora, Veo, Pika, Kling, LTX & more) with pay-as-you-go credits. | [🔗](https://maxvideoai.com) |
 | PVID | Free AI video generator aggregating Kling 3.0, Sora 2, Veo 3.1 with 100 free credits | [🔗](http://pvid.app/) |
 | nearerai | AI Photo Restoration: Revive Your Cherished Memories. | [🔗](https://nearerai.com/) |


### PR DESCRIPTION
Adds SEELE TV to the Art & Creativity section using the existing list format.\n\nSEELE TV is a cinematic AI video studio focused on scene consistency and shot-level camera control. The entry links to the official product site and uses a concise, factual description.