### PR TITLE
Add LearnClash to Education

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Curated list of top AI Tools.
 | Read PDF Aloud | Let AI Read Your PDF Aloud with Natural Voice | [🔗](https://readpdfaloud.com/) |
 
 | AIHumanLove | Free AI tools directory with 1,500+ tools, free AI courses for beginners, a 175+ prompt library, and 37 interactive experiments | [🔗](https://aihumanlove.com) |
+| LearnClash | AI-powered 1v1 quiz duels on any topic, with an explanation after every answer and Elo-based matching | [🔗](https://learnclash.com) |
 ## Developer
 
 | Tools | Used for | Link |

--- a/README.md
+++ b/README.md
@@ -282,9 +282,9 @@ Curated list of top AI Tools.
 | Fluenly | AI Language Learning App with Goal Driven Speaking Scenarios | [🔗](https://fluenly.ai/) |
 | MMIPractice.org | Free practice questions and AI coaching for MMI prep | [🔗](https://www.mmipractice.org/) |
 | Read PDF Aloud | Let AI Read Your PDF Aloud with Natural Voice | [🔗](https://readpdfaloud.com/) |
+| LearnClash | AI-powered 1v1 quiz duels on any topic, with an explanation after every answer and Elo-based matching | [🔗](https://learnclash.com) |
 
 | AIHumanLove | Free AI tools directory with 1,500+ tools, free AI courses for beginners, a 175+ prompt library, and 37 interactive experiments | [🔗](https://aihumanlove.com) |
-| LearnClash | AI-powered 1v1 quiz duels on any topic, with an explanation after every answer and Elo-based matching | [🔗](https://learnclash.com) |
 ## Developer
 
 | Tools | Used for | Link |


### PR DESCRIPTION
Adds LearnClash to the Education table (appended at the end of the table).

LearnClash is a learning app built around 1v1 quiz duels: pick any of 800+ topics, get matched by Elo rating, and every answer comes with an explanation so the misses stick. iOS + Android, free tier with no ads, EN/DE/FR/ES.

Disclosure: I am the founder (Pluxia GmbH). Happy to adjust the wording or placement if you prefer a different format.