### PR TITLE
Add BrandQuill to Productivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Curated list of top AI Tools.
 
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |
+| BrandQuill | Turn ChatGPT and other AI responses into branded, editable Word documents using your own DOCX or DOTX template | [🔗](https://brandquill.app/?utm_source=github&utm_medium=directory&utm_campaign=top_ai_tools) |
 | Tudo | AI task manager for iPhone that turns voice notes, screenshots, and text into organized tasks and plans. | [🔗](https://blynkai.app/tudo/) |
 | Remio | Local-first AI memory and knowledge base that parses files, webpages, recordings, emails, and notes into local indexes for faster personal-context retrieval | [🔗](https://remio.ai/) |
 | Orkas | Open-source, local-first desktop AI workforce coordinated by a Commander through one chat | [🔗](https://orkas.ai/?source=gh_topaitools) |


### PR DESCRIPTION
Adds BrandQuill to the Productivity section using the repository format. BrandQuill turns reviewed responses from ChatGPT and other AI assistants into editable Word documents using a user-provided DOCX or DOTX template.\n\nDisclosure: I am the product owner. The entry links directly to the product with source attribution parameters.