### PR TITLE
Add Wan3Video to Art & Creativity tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Curated list of top AI Tools.
 
 | Tools | Used for | Link |
 |------ | ------------ | :----------: |
+| [Wan3Video](https://wan3video.co) | Independent browser-based Wan 3.0 text-to-video and image-to-video generator with prompt guides and model comparisons | Free + Premium |
 | DoreArt AI | AI music generator for creating original songs, vocals, lyrics, and instrumental tracks from text prompts | [🔗](https://doreartai.com) |
 | AI Dog Generator | Create AI-generated dog photos or transform your own dog into a variety of artistic styles | [🔗](https://aidoggenerator.com) |
 | [NanoBanana2](https://nanobanana2.com) | Free AI image generator with trend-aware templates, multiple AI models, and advanced editing tools | Free + Premium |


### PR DESCRIPTION
## Summary

Adds Wan3Video to the Art & Creativity tools list.

Wan3Video is an independent browser-based platform for Wan 3.0
text-to-video and image-to-video generation, with prompt guides
and model comparisons.

- Website: https://wan3video.co
- Pricing: Free + Premium

## Disclosure

I am affiliated with Wan3Video.