### PR TITLE
Add XiuRouter to Developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Curated list of top AI Tools.
 | Lucebox | The computer for local AI |[🔗](https://www.lucebox.com/)|
 | StackPicks | Curated directory of open-source dev tools and AI products with editorial takes — what each does, the honest tradeoff, who should skip. ~200 picks. | [🔗](https://stackpicks.dev) |
 | Tura | Local-first open-source coding agent with CLI, TUI, and GUI interfaces, built-in verification, and reproducible public benchmarks. | [🔗](https://github.com/Tura-AI/tura) |
+| XiuRouter | Hosted multi-model API with native OpenAI Responses and Chat Completions, Anthropic Messages, Gemini GenerateContent, scoped keys, and request-level usage and cost records. | [🔗](https://router.xiu.ai/) |
 
 
 ## Gaming, 3D, Motion


### PR DESCRIPTION
## Summary

Adds XiuRouter to the Developer section as a hosted multi-model API for applications and AI agents. The entry uses stable public facts only: native OpenAI Responses and Chat Completions, Anthropic Messages, Gemini GenerateContent, scoped keys, and request-level usage and cost records.

## Verification

- XiuRouter and `router.xiu.ai` were absent from the upstream README and existing pull requests before submission.
- The product homepage returns HTTP 200.
- `git diff --check` passes.
- The PR changes one README row only.

Disclosure: I am affiliated with XiuRouter and XiuLab Inc.