### PR TITLE
Add wan 3.0 video AI video generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Curated list of top AI Tools.
 | Seele AI | No-code AI game maker for creating playable 2D/3D games from text prompts | [🔗](https://www.seeles.ai/)|
 | Scenario | creating AI-generated game assets | [🔗](https://www.scenario.gg/)|
 | MeshGPT | AI-Powered 3D Model Generation & Optimization | [🔗](https://meshgpt.io/)|
+| [wan 3.0 video](https://wan3pro.video) | Hosted AI video generator for the open Wan series, supporting text-to-video and image-to-video workflows | [🔗](https://wan3pro.video) |
 
 ## Sales/Marketing
 


### PR DESCRIPTION
Adds [wan 3.0 video](https://wan3pro.video) as an AI video generator in the Gaming, 3D, Motion category.