### PR TITLE
Add LLM Pulse to Sales/Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ Curated list of top AI Tools.
 | MyndField | World's First Decision Engine | [🔗](https://myndfield.ai/) |
 | Tuku | TikTok comment-to-DM automation for SEA creators & merchants. | [🔗](https://tuku.co/) |
 | Flypost | AI LinkedIn content studio — turns blogs, videos & docs into on-brand LinkedIn posts, carousels & articles | [🔗](https://www.flypost.io/) |
+| LLM Pulse | Monitors brand mentions, citations, sentiment, and competitor share of voice across AI search engines. | [🔗](https://llmpulse.ai/) |
 
 
 ## Productivity


### PR DESCRIPTION
## Summary

Adds one factual row for LLM Pulse to the existing Sales/Marketing table.

## Fit

LLM Pulse monitors brand mentions, citations, sentiment, and competitor share of voice across AI search engines. The canonical product page is live at https://llmpulse.ai/, and its public API specification is available at https://api.llmpulse.ai/openapi.json.

Disclosure: I am a co-founder of LLM Pulse.