### PR TITLE
Add BigPipe to Sales/Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,7 +473,7 @@ Curated list of top AI Tools.
 | MyndField | World's First Decision Engine | [🔗](https://myndfield.ai/) |
 | Tuku | TikTok comment-to-DM automation for SEA creators & merchants. | [🔗](https://tuku.co/) |
 | Flypost | AI LinkedIn content studio — turns blogs, videos & docs into on-brand LinkedIn posts, carousels & articles | [🔗](https://www.flypost.io/) |
-
+| BigPipe | AI that turns a marketing agency's expertise into a self-running company, building and operating its website, product, billing, and back office on autopilot. | [🔗](https://bigpipe.agency) |
 
 ## Productivity
 


### PR DESCRIPTION
Adds BigPipe to the Sales/Marketing section. BigPipe is an AI that turns a marketing or growth agency's expertise into an owned, self-running company (website, product, billing, and back office), for agency owners who want to own a compounding business asset instead of billing hours. Single-line addition matching the section format.